### PR TITLE
Add bootstrap 4 size XL in bootstrap_size_match

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -368,13 +368,23 @@ class FormHelper(DynamicLayoutHandler):
             'field_class': self.field_class,
             'include_media': self.include_media
         }
-        bootstrap_size_match = re.findall('col-(lg|md|sm|xs)-(\d+)', self.label_class)
-        if bootstrap_size_match:
-            if template_pack == 'bootstrap4':
-                offset_pattern = 'offset-%s-%s'
-            else:
-                offset_pattern = 'col-%s-offset-%s'
-            items['bootstrap_checkbox_offsets'] = [offset_pattern % m for m in bootstrap_size_match]
+        
+        if template_pack == 'bootstrap4':
+            bootstrap_size_match = re.findall('col-(xl|lg|md|sm)-(\d+)', self.label_class)
+            if bootstrap_size_match:
+                if template_pack == 'bootstrap4':
+                    offset_pattern = 'offset-%s-%s'
+                else:
+                    offset_pattern = 'col-%s-offset-%s'
+                items['bootstrap_checkbox_offsets'] = [offset_pattern % m for m in bootstrap_size_match]
+        else:
+            bootstrap_size_match = re.findall('col-(lg|md|sm|xs)-(\d+)', self.label_class)
+            if bootstrap_size_match:
+                if template_pack == 'bootstrap4':
+                    offset_pattern = 'offset-%s-%s'
+                else:
+                    offset_pattern = 'col-%s-offset-%s'
+                items['bootstrap_checkbox_offsets'] = [offset_pattern % m for m in bootstrap_size_match]
 
         items['attrs'] = {}
         if self.attrs:


### PR DESCRIPTION
Bootstrap 4 introduce XL in col sizes for responsive (and remove XS).
When a horizontal-form is used crispy form generate an offest-{responsive-breakpoint}-{col-size} class for field without label.

This PR check the col size according to bootstrap version